### PR TITLE
fix: prevent from getting nil pointer

### DIFF
--- a/pkg/tasks/evmtask/transaction.go
+++ b/pkg/tasks/evmtask/transaction.go
@@ -58,6 +58,11 @@ func (e *Transaction) Run(ctx context.Context, tp *common.TaskParameters) error 
 			continue
 		}
 
+		if evmTxn == nil {
+			log.Errorf("Got nil evmTxn, hash: %v", ethHash)
+			continue
+		}
+
 		evmTransaction := &evmmodel.Transaction{
 			Height:  int64(tp.AncestorTs.Height()),
 			Version: tp.Version,


### PR DESCRIPTION
Got error log:
```
time="2024-06-20T01:32:06Z" level=info msg="receive tipset: 4017761/version: 0"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x13dba79]
goroutine 12 [running]:
[github.com/Spacescore/observatory-task/pkg/tasks/evmtask.(*Transaction).Run(0x1b33250](http://github.com/Spacescore/observatory-task/pkg/tasks/evmtask.(*Transaction).Run(0x1b33250)?, {0x1b33250, 0xc0000b0e60}, 0xc00079a580)
	/opt/pkg/tasks/evmtask/transaction.go:64 +0x519
[github.com/Spacescore/observatory-task/internal/busi/core/consume.ConsumeTipset({0x1b33250](http://github.com/Spacescore/observatory-task/internal/busi/core/consume.ConsumeTipset(%7B0x1b33250), 0xc0000b0e60}, 0xc00079a580, {0x1b2ebd0, 0x2f51da0})
	/opt/internal/busi/core/consume/consume.go:58 +0x322
[github.com/Spacescore/observatory-task/internal/busi.(*MetaTask).fetchMessage(0xc00068e300](http://github.com/Spacescore/observatory-task/internal/busi.(*MetaTask).fetchMessage(0xc00068e300), {0x1b33250, 0xc0000b0e60}, 0xc000155b08, {0x1b2ebd0, 0x2f51da0})
	/opt/internal/busi/meta_task.go:131 +0x2f4
[github.com/Spacescore/observatory-task/internal/busi.(*MetaTask).Watcher(0xc00068e300](http://github.com/Spacescore/observatory-task/internal/busi.(*MetaTask).Watcher(0xc00068e300), {0x1b33250, 0xc0000b0e60})
	/opt/internal/busi/meta_task.go:96 +0xb2
[github.com/Spacescore/observatory-task/internal/busi.MetaTaskStart({0x1b33250](http://github.com/Spacescore/observatory-task/internal/busi.MetaTaskStart(%7B0x1b33250), 0xc0000b0e60}, 0x0?, 0x0?)
	/opt/internal/busi/meta_task.go:79 +0x85
created by [github.com/Spacescore/observatory-task/internal/busi.(*Task).Start](http://github.com/Spacescore/observatory-task/internal/busi.(*Task).Start) in goroutine 1
	/opt/internal/busi/server.go:48 +0x1a5
```